### PR TITLE
Feature1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	asciidoctorExt "org.springframework.restdocs:spring-restdocs-asciidoctor:${asciidocVersion}"
 	testImplementation "org.springframework.restdocs:spring-restdocs-mockmvc:${asciidocVersion}"
+	implementation 'mysql:mysql-connector-java'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pointreserve/reserves/account/application/service/AccountService.java
+++ b/src/main/java/com/pointreserve/reserves/account/application/service/AccountService.java
@@ -10,8 +10,11 @@ import com.pointreserve.reserves.account.ui.dto.AccountEdit;
 import com.pointreserve.reserves.account.ui.dto.AccountResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.LockModeType;
 
 @Slf4j
 @Service
@@ -46,11 +49,11 @@ public class AccountService {
         AccountEditor accountEditor = amountEditorBuilder.totalAmount(accountEdit.getTotalAmount()).build();
 
         account.edit(accountEditor);
-        Account saveResult = accountRepository.save(account);
+        Account saveResult = accountRepository.saveAndFlush(account);
 
         return new AccountResponse(saveResult);
     }
-    @Transactional(readOnly = true)
+    @Transactional
     public AccountResponse getAccount( Long memberId ){
         Account account = accountRepository.getByMemberId(memberId)
                 .orElseThrow(() -> new AccountNotFound());

--- a/src/main/java/com/pointreserve/reserves/account/infra/AccountRepositoryCustom.java
+++ b/src/main/java/com/pointreserve/reserves/account/infra/AccountRepositoryCustom.java
@@ -1,7 +1,9 @@
 package com.pointreserve.reserves.account.infra;
 
 import com.pointreserve.reserves.account.domain.Account;
+import org.springframework.data.jpa.repository.Lock;
 
+import javax.persistence.LockModeType;
 import java.util.Optional;
 
 public interface AccountRepositoryCustom {

--- a/src/main/java/com/pointreserve/reserves/account/infra/AccountRespositoryImpl.java
+++ b/src/main/java/com/pointreserve/reserves/account/infra/AccountRespositoryImpl.java
@@ -4,6 +4,7 @@ import com.pointreserve.reserves.account.domain.Account;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import javax.persistence.LockModeType;
 import java.util.Optional;
 
 import static com.pointreserve.reserves.account.domain.QAccount.account;
@@ -18,6 +19,7 @@ public class AccountRespositoryImpl implements AccountRepositoryCustom {
     public Optional<Account> getByMemberId(Long memberId) {
         return Optional.of(jpaQueryFactory.selectFrom(account)
                 .where(account.memberId.eq(memberId))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                 .fetchOne());
     }
 }

--- a/src/main/java/com/pointreserve/reserves/eventDetail/application/service/EventDetailService.java
+++ b/src/main/java/com/pointreserve/reserves/eventDetail/application/service/EventDetailService.java
@@ -215,7 +215,7 @@ public class EventDetailService {
         for( EventDetail e : eventDetailList ) {
             EventDetail newEventDetail = eventDetailRepository.save( EventDetail.builder()
                     .membershipId(nowEvent.getMembershipId()) // 새로운 이벤트
-                    .status(ReservesStatus.CANCLE_REDEEM)                           // 사용 취소는 다시 적립
+                    .status(ReservesStatus.CANCLE_REDEEM)     // 사용 취소는 다시 적립
                     .amount(e.getAmount() * (-1))             // 이전 사용 금액을 다시 원복
                     .eventId(nowEvent.getEventId())           // 이벤트 ID는 이번에 발생한 이벤트
                     .cancelId(e.getId())                      // 취소 ID는 이전 ID

--- a/src/main/java/com/pointreserve/reserves/eventReserves/application/facade/EventReservesFacade.java
+++ b/src/main/java/com/pointreserve/reserves/eventReserves/application/facade/EventReservesFacade.java
@@ -8,14 +8,12 @@ import com.pointreserve.reserves.eventDetail.ui.dto.EventDetailCreate;
 import com.pointreserve.reserves.eventReserves.application.service.EventReservesService;
 import com.pointreserve.reserves.eventReserves.domain.EventReserves;
 import com.pointreserve.reserves.eventReserves.domain.ReservesStatus;
-import com.pointreserve.reserves.eventReserves.exception.EventReservesNotFound;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesCancel;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesCreate;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import static java.lang.Math.abs;
 

--- a/src/main/java/com/pointreserve/reserves/eventReserves/application/facade/EventReservesFacade.java
+++ b/src/main/java/com/pointreserve/reserves/eventReserves/application/facade/EventReservesFacade.java
@@ -1,50 +1,41 @@
-package com.pointreserve.reserves.eventReserves.application.service;
+package com.pointreserve.reserves.eventReserves.application.facade;
 
 import com.pointreserve.reserves.account.application.service.AccountService;
 import com.pointreserve.reserves.account.ui.dto.AccountEdit;
 import com.pointreserve.reserves.account.ui.dto.AccountResponse;
 import com.pointreserve.reserves.common.component.EventPublisher;
 import com.pointreserve.reserves.eventDetail.ui.dto.EventDetailCreate;
+import com.pointreserve.reserves.eventReserves.application.service.EventReservesService;
 import com.pointreserve.reserves.eventReserves.domain.EventReserves;
-import com.pointreserve.reserves.eventReserves.infra.EventReservesRepository;
 import com.pointreserve.reserves.eventReserves.domain.ReservesStatus;
 import com.pointreserve.reserves.eventReserves.exception.EventReservesNotFound;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesCancel;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesCreate;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesResponse;
-import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesSearch;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static java.lang.Math.*;
+import static java.lang.Math.abs;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class EventReservesService {
+public class EventReservesFacade {
+
     private final EventPublisher publisher;
-    private final EventReservesRepository eventReservesRepository;
+
+    private final EventReservesService eventReservesService;
 
     private final AccountService accountService;
 
-    @Transactional
-    public EventReserves saveEventReserves(EventReserves e) {
-        return eventReservesRepository.save(e);
-    }
-
-
-    @Transactional
     public EventReservesResponse createEventReserves(EventReservesCreate eventReservesCreate) {
 
         EventReserves eventReserves = eventReservesCreate.toEntity();
 
-        // 업데이트 대상 조회
         AccountResponse accountResponse = accountService.getAccount(eventReserves.getMemberId());
+
         // 금액 계산
         AccountEdit accountEdit = AccountEdit.builder()
                 .totalAmount(calUpdateAmount( eventReserves, accountResponse.getTotalAmount() ))
@@ -53,8 +44,8 @@ public class EventReservesService {
         accountEdit.isValid();
         // 업데이트 요청
         accountService.updateAccount(eventReserves.getMemberId(), accountEdit);
-        // 저장
-        EventReserves saveResult = eventReservesRepository.save(eventReserves);
+        // 이벤트 저장
+        EventReserves saveResult = eventReservesService.saveEventReserves(eventReserves);
         // 이벤트 발행
         EventDetailCreate eventDetailCreate = new EventDetailCreate(saveResult);
         eventDetailCreate.updateEventStatus(EventDetailCreate.EventStatus.STANDBY);
@@ -66,15 +57,11 @@ public class EventReservesService {
                 .build();
     }
 
-    @Transactional
     public EventReservesResponse createCancelEventReserves(EventReservesCancel eventReservesCancel){
         String beforeEventId = eventReservesCancel.getEventId();
         EventReserves eventReserves = eventReservesCancel.toEntity();
-
-        EventReserves beforeHistory = eventReservesRepository.findById(beforeEventId)
-                .orElseThrow(()->{throw new EventReservesNotFound();});
-
-
+        // 이전 정보 조회
+        EventReservesResponse beforeHistory = eventReservesService.getEventReserves(beforeEventId);
         // 업데이트 대상 조회
         AccountResponse accountResponse = accountService.getAccount(eventReserves.getMemberId());
         // 금액 계산
@@ -86,10 +73,9 @@ public class EventReservesService {
         // 업데이트 요청
         accountService.updateAccount(eventReserves.getMemberId(), accountEdit);
         // 저장
-        EventReserves saveResult = eventReservesRepository.save(eventReserves);
+        EventReserves saveResult = eventReservesService.saveEventReserves(eventReserves);
         // 이벤트 발행
         EventDetailCreate eventDetailCreate = new EventDetailCreate(saveResult);
-//        eventDetailCreate.setEventId(eventReservesCancel.getEventId());
         eventDetailCreate.setBeforeHistoryId(beforeEventId);
         eventDetailCreate.updateEventStatus(EventDetailCreate.EventStatus.STANDBY);
         publisher.publish(eventDetailCreate);
@@ -99,26 +85,8 @@ public class EventReservesService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
-    public EventReservesResponse getEventReserves(String eventId){
-        EventReserves eventReserves = eventReservesRepository.findById(eventId).orElseThrow(
-                () -> new EventReservesNotFound()
-        );
-        return EventReservesResponse.builder().eventReserves(eventReserves).build();
-    }
-
-    public List<EventReservesResponse> getEventReservesList(EventReservesSearch eventReservesSearch){
-        List<EventReservesResponse> responseList = eventReservesRepository.getList(eventReservesSearch)
-                .stream().map(EventReservesResponse::new)
-                .collect(Collectors.toList());
-        if(responseList.isEmpty()){
-            throw new EventReservesNotFound();
-        }
-        return responseList;
-    }
-
-
-    private int calUpdateAmount( EventReserves e, int beforeTotalAmount ) {
+    private int calUpdateAmount(EventReserves e, int beforeTotalAmount) {
         return ( (e.getStatus() == ReservesStatus.SAVEUP) ? e.getAmount() : e.getAmount()*(-1) ) + beforeTotalAmount;
     }
+
 }

--- a/src/main/java/com/pointreserve/reserves/eventReserves/application/service/EventReservesService.java
+++ b/src/main/java/com/pointreserve/reserves/eventReserves/application/service/EventReservesService.java
@@ -37,7 +37,7 @@ public class EventReservesService {
         return eventReservesRepository.save(e);
     }
 
-
+    // 테스트 외 사용안함
     @Transactional
     public EventReservesResponse createEventReserves(EventReservesCreate eventReservesCreate) {
 
@@ -66,6 +66,7 @@ public class EventReservesService {
                 .build();
     }
 
+    // 테스트 외 사용안함
     @Transactional
     public EventReservesResponse createCancelEventReserves(EventReservesCancel eventReservesCancel){
         String beforeEventId = eventReservesCancel.getEventId();
@@ -89,7 +90,6 @@ public class EventReservesService {
         EventReserves saveResult = eventReservesRepository.save(eventReserves);
         // 이벤트 발행
         EventDetailCreate eventDetailCreate = new EventDetailCreate(saveResult);
-//        eventDetailCreate.setEventId(eventReservesCancel.getEventId());
         eventDetailCreate.setBeforeHistoryId(beforeEventId);
         eventDetailCreate.updateEventStatus(EventDetailCreate.EventStatus.STANDBY);
         publisher.publish(eventDetailCreate);

--- a/src/main/java/com/pointreserve/reserves/eventReserves/infra/EventReservesRepositoryImpl.java
+++ b/src/main/java/com/pointreserve/reserves/eventReserves/infra/EventReservesRepositoryImpl.java
@@ -19,6 +19,7 @@ public class EventReservesRepositoryImpl implements EventReservesRepositoryCusto
                 .where(QEventReserves.eventReserves.memberId.eq(eventReservesSearch.getMemberId()))
                 .limit(eventReservesSearch.getSize())
                 .offset(eventReservesSearch.getOffset())
+                .orderBy(QEventReserves.eventReserves.effectiveData.asc())
                 .fetch();
     }
 }

--- a/src/main/java/com/pointreserve/reserves/eventReserves/ui/controller/EventReservesController.java
+++ b/src/main/java/com/pointreserve/reserves/eventReserves/ui/controller/EventReservesController.java
@@ -1,5 +1,6 @@
 package com.pointreserve.reserves.eventReserves.ui.controller;
 
+import com.pointreserve.reserves.eventReserves.application.facade.EventReservesFacade;
 import com.pointreserve.reserves.eventReserves.application.service.EventReservesService;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesCancel;
 import com.pointreserve.reserves.eventReserves.ui.dto.EventReservesCreate;
@@ -18,6 +19,8 @@ public class EventReservesController {
 
     private final EventReservesService eventReservesService;
 
+    private final EventReservesFacade eventReservesFacade;
+
     @GetMapping("/reserves/events/get/{eventId}")
     public EventReservesResponse getEvent(@PathVariable(name = "eventId") String eventId){
         return eventReservesService.getEventReserves(eventId);
@@ -32,13 +35,15 @@ public class EventReservesController {
     public EventReservesResponse createEvent(@RequestBody EventReservesCreate params) {
         params.isAmountValid();
         params.isStatusValid();
-        return eventReservesService.createEventReserves(params);
+//        return eventReservesService.createEventReserves(params);
+        return eventReservesFacade.createEventReserves(params);
     }
 
     @PostMapping("/reserves/event/cancel")
     public EventReservesResponse createCacelEvent(@RequestBody EventReservesCancel params) {
         params.isStatusValid();
-        return eventReservesService.createCancelEventReserves(params);
+//        return eventReservesService.createCancelEventReserves(params);
+        return eventReservesFacade.createCancelEventReserves(params);
     }
 
 }

--- a/src/main/java/com/pointreserve/reserves/eventReserves/ui/controller/EventReservesController.java
+++ b/src/main/java/com/pointreserve/reserves/eventReserves/ui/controller/EventReservesController.java
@@ -35,14 +35,12 @@ public class EventReservesController {
     public EventReservesResponse createEvent(@RequestBody EventReservesCreate params) {
         params.isAmountValid();
         params.isStatusValid();
-//        return eventReservesService.createEventReserves(params);
         return eventReservesFacade.createEventReserves(params);
     }
 
     @PostMapping("/reserves/event/cancel")
     public EventReservesResponse createCacelEvent(@RequestBody EventReservesCancel params) {
         params.isStatusValid();
-//        return eventReservesService.createCancelEventReserves(params);
         return eventReservesFacade.createCancelEventReserves(params);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,20 +1,42 @@
+#spring:
+#  profiles:
+#
+#  datasource:
+#    url: jdbc:h2:mem:testdb
+#    driverClassName: org.h2.Driver
+#    username: sa
+#    password:
+#  jpa:
+#    show-sql: true
+#    hibernate:
+#      ddl-auto: create-drop
+#  h2:
+#    console:
+#      enabled: true
+#  devtools:
+#    livereload:
+#      enabled: true
+#    restart:
+#      enabled: true
 spring:
-  profiles:
-
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driverClassName: org.h2.Driver
-    username: sa
-    password:
   jpa:
-    show-sql: true
     hibernate:
-      ddl-auto: create-drop
-  h2:
-    console:
-      enabled: true
-  devtools:
-    livereload:
-      enabled: true
-    restart:
-      enabled: true
+      ddl-auto: create
+    show-sql: true
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:33306/STOCK
+    username: root
+    password: 123456
+    hikari:
+      maximun-pool-size: 40
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: DEBUG
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE

--- a/src/test/java/com/pointreserve/reserves/eventReserves/application/facade/EventReservesFacadeTest.java
+++ b/src/test/java/com/pointreserve/reserves/eventReserves/application/facade/EventReservesFacadeTest.java
@@ -1,0 +1,35 @@
+package com.pointreserve.reserves.eventReserves.application.facade;
+
+import com.pointreserve.reserves.account.application.service.AccountService;
+import com.pointreserve.reserves.common.component.EventPublisher;
+import com.pointreserve.reserves.eventReserves.application.service.EventReservesService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class EventReservesFacadeTest {
+
+    @Autowired
+    private EventReservesFacade eventReservesFacade;
+
+    @MockBean
+    private AccountService accountService;
+
+    @MockBean
+    private EventReservesService eventReservesService;
+
+    @MockBean
+    private EventPublisher publisher;
+
+    @Test
+    void createEventReserves() {
+    }
+
+    @Test
+    void createCancelEventReserves() {
+    }
+}

--- a/src/test/java/com/pointreserve/reserves/eventReserves/application/service/EventReservesServiceTest.java
+++ b/src/test/java/com/pointreserve/reserves/eventReserves/application/service/EventReservesServiceTest.java
@@ -138,7 +138,7 @@ class EventReservesServiceTest {
         for(int i = 0; i < 100; i++) {
             givenList.add(EventReserves.builder().memberId(1L).amount(i+1).status(SAVEUP).build());
         }
-        List<EventReserves> saveResult = eventReservesRepository.saveAll(givenList);
+        List<EventReserves> saveResult = eventReservesRepository.saveAllAndFlush(givenList);
 
         // when
         List<EventReservesResponse> responseList = eventReservesService.getEventReservesList(EventReservesSearch.builder()
@@ -147,9 +147,12 @@ class EventReservesServiceTest {
                         .size(10)
                 .build());
 
+        System.out.println(responseList.size());
+
         // then
         Assertions.assertEquals(responseList.size(), 10);
         for(int i = 0; i < responseList.size(); i++) {
+            System.out.println(responseList.get(i).getMemberId() + " " + responseList.get(i).getAmount() + " " + responseList.get(i).getStatus());
             Assertions.assertEquals(responseList.get(i).getMemberId(), 1L);
             Assertions.assertEquals(responseList.get(i).getAmount(), saveResult.get(i).getAmount());
             Assertions.assertEquals(responseList.get(i).getStatus(), saveResult.get(i).getStatus());


### PR DESCRIPTION
사람들이 포인트를 적립할 때 발생 할수 있는 동시성을 제어하고자 합니다.

일반적으로 사용자 시나리오를 생각해보았습니다. 포인트 적립, 사용을 바코드를 공유해서 여러 사람이 사용합니다.
그렇기에 포인트 사용, 적립 후 총계를 집계하는 과정에서 동시성 이슈가 생길 수 있습니다.
금전과 관련된 부분이라 생각하여 비관적 락을 적용하였습니다.