### PR TITLE
Transactional annotation 점검

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:11-jre
+COPY build/libs/*.jar app.jar
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/src/main/java/com/pointreserve/reserves/accumulationpoint/application/service/AccumulatedPointService.java
+++ b/src/main/java/com/pointreserve/reserves/accumulationpoint/application/service/AccumulatedPointService.java
@@ -11,8 +11,11 @@ import com.pointreserve.reserves.accumulationpoint.ui.dto.AccumulatedPointRespon
 import com.pointreserve.reserves.point.domain.PointStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.LockModeType;
 
 import static com.pointreserve.reserves.point.domain.PointStatus.REDEEM;
 

--- a/src/main/java/com/pointreserve/reserves/accumulationpoint/infra/AccumulatedPointRespositoryImpl.java
+++ b/src/main/java/com/pointreserve/reserves/accumulationpoint/infra/AccumulatedPointRespositoryImpl.java
@@ -20,7 +20,6 @@ public class AccumulatedPointRespositoryImpl implements AccountRepositoryCustom 
     public Optional<AccumulatedPoint> getByMemberId(Long memberId) {
         return Optional.of(Objects.requireNonNull(jpaQueryFactory.selectFrom(accumulatedPoint)
                 .where(accumulatedPoint.memberId.eq(memberId))
-                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                 .fetchOne()));
     }
 }


### PR DESCRIPTION
- Service 레이어에서 DB Lock을 설정한고 들어서 해당 부분을 점검하였습니다.
- 위 내용을 들었던 이유는 repository layer에 걸면 매번 DB를 조회할때마다 Lock이 걸린다고 하여 해당 Lock을 service 레이어에서 처리하고자 하였습니다.
- LockModeType.java에서 보면 LockMode의 종류가 있는데 제가 사용한 LockMode.PESSIMISTIC_WRITE은 write시 걸리는 Lock입니다. read와는 무관하다고 판단하여 사용하였습니다.